### PR TITLE
Update mn_setup_hot_cold_wallet.md

### DIFF
--- a/guides/mn_setup_hot_cold_wallet.md
+++ b/guides/mn_setup_hot_cold_wallet.md
@@ -52,7 +52,7 @@ Update and Install new packages by running the following commands in one go, one
 ```
 apt-get update && \
 apt-get upgrade -y && \
-apt-get install wget nano unrar unzip libboost-all-dev libevent-dev software-properties-common -y && \
+apt-get install wget nano unzip libboost-all-dev libevent-dev software-properties-common -y && \
 add-apt-repository ppa:bitcoin/bitcoin -y && \
 apt-get update && \
 apt-get install libdb4.8-dev libdb4.8++-dev -y
@@ -260,7 +260,7 @@ The file will contain an example that is commented out(with a # in front). Read 
 ```
 MN1 199.247.10.25:9020 87LBTcfgkepEddWNFrJcut76rFp9wQG6rgbqPhqHWGvy13A9hJK c19972e47d2a77d3ff23c2dbd8b2b204f9a64a46fed0608ce57cf76ba9216487 1
 ```
-
+Where `MN1` is the nodes alias.  
 Where `199.247.10.25` is the external IP of the masternode server that will provide services to the network.
 
 Where `87LBTcfgkepEddWNFrJcut76rFp9wQG6rgbqPhqHWGvy13A9hJK` is your masternode key from (Part 1), the value used for `masternodeprivkey` in `/root/.rupaya/rupaya.conf`.

--- a/guides/mn_setup_hot_cold_wallet.md
+++ b/guides/mn_setup_hot_cold_wallet.md
@@ -261,6 +261,7 @@ The file will contain an example that is commented out(with a # in front). Read 
 MN1 199.247.10.25:9020 87LBTcfgkepEddWNFrJcut76rFp9wQG6rgbqPhqHWGvy13A9hJK c19972e47d2a77d3ff23c2dbd8b2b204f9a64a46fed0608ce57cf76ba9216487 1
 ```
 Where `MN1` is the nodes alias.  
+
 Where `199.247.10.25` is the external IP of the masternode server that will provide services to the network.
 
 Where `87LBTcfgkepEddWNFrJcut76rFp9wQG6rgbqPhqHWGvy13A9hJK` is your masternode key from (Part 1), the value used for `masternodeprivkey` in `/root/.rupaya/rupaya.conf`.


### PR DESCRIPTION
Apt installs fail at unrar. (no valid candidate)
unrar doesn't appear to be required for the rest of the process.

Clarified Masternode alias setting.